### PR TITLE
Exposure

### DIFF
--- a/irf/__init__.py
+++ b/irf/__init__.py
@@ -1,4 +1,4 @@
 from .collection_area import collection_area
+from .exposure_map import estimate_exposure_time, build_exposure_map
 
-
-__all__ = ['collection_area']
+__all__ = ['collection_area', 'estimate_exposure_time', 'build_exposure_map']

--- a/irf/exposure_map.py
+++ b/irf/exposure_map.py
@@ -1,0 +1,113 @@
+import astropy.units as u
+from astropy.coordinates import Angle, SkyCoord
+from regions import CircleSkyRegion
+from astroquery.skyview import SkyView
+from astropy.wcs import WCS
+import matplotlib.pyplot as plt
+import fact.io as fio
+import numpy as np
+import pandas as pd
+from scipy.stats import expon
+
+
+def estimate_exposure_time(timestamps):
+    '''
+    Takes numpy datetime64[ns] timestamps and returns an estimates of the exposure time in seconds
+    '''
+    delta_s = np.diff(timestamps).astype(int) * float(1e-9)
+    # take only events that came within 30 seconds or so
+    delta_s = delta_s[delta_s < 30]
+    scale = delta_s.mean()
+
+    exposure_time = len(delta_s) * scale
+    loc = min(delta_s)
+
+    # this percentile is somewhat abritrary but seems to work well.
+    live_time_fraction = 1 - expon.ppf(0.1, loc=loc, scale=scale)
+
+    return (exposure_time * live_time_fraction) * u.s
+
+
+@u.quantity_input(ra=u.hourangle, dec=u.deg, fov=u.deg)
+def build_exposure_regions(pointing_coords, fov=4.5 * u.deg):
+    unique_pointing_positions = SkyCoord(
+        ra=np.unique(pointing_coords.ra),
+        dec=np.unique(pointing_coords.dec)
+    )
+
+    regions = [CircleSkyRegion(
+        center=pointing,
+        radius=Angle(fov) / 2
+    ) for pointing in unique_pointing_positions]
+
+    return unique_pointing_positions, regions
+
+
+@u.quantity_input(event_ra=u.hourangle, event_dec=u.deg, fov=u.deg)
+def build_exposure_map(pointing_coords, event_time, fov=4.5 * u.deg):
+    unique_pointing_positions, regions = build_exposure_regions(pointing_coords)
+
+    img_center = SkyCoord(ra=pointing_coords.ra.mean(), dec=pointing_coords.dec.mean())
+    print('getting image')
+    hdu = SkyView.get_images(position=img_center, pixels=1000, survey=['DSS'], width=2 * fov, height=2 * fov)[0][0]
+    img = hdu.data
+    wcs = WCS(hdu.header)
+
+    print('starting loop')
+    times = []
+    for p in unique_pointing_positions:
+        m = (pointing_coords.ra == p.ra) & (pointing_coords.dec == p.dec)
+        exposure_time = estimate_exposure_time(event_time[m])
+        print(exposure_time.to('h'))
+        times.append(exposure_time)
+
+    print(sum(times).to('h'))
+
+    # import IPython; IPython.embed()
+    masks = [r.to_pixel(wcs).to_mask().to_image(img.shape) for r in regions]
+    #
+    cutout = sum(masks).astype(bool)
+    mask = sum([w * m for w, m in zip(times, masks)])
+
+    return np.ma.masked_array(mask.to('h'), mask=~cutout), wcs, img
+
+
+def plot_exposure(img, mask, wcs):
+    ax = plt.subplot(projection=wcs)
+
+    ax.imshow(img, cmap='gray')
+    d = ax.imshow(mask, alpha=0.7)
+    cb = plt.colorbar(d)
+    cb.set_label('Live Time / Hours')
+    ax.set_xlabel('Galactic Longitude')
+    ax.set_ylabel('Galactic Latitude')
+
+    crab = SkyCoord.from_name('Crab Nebula')
+    ax.scatter(crab.ra.deg, crab.dec.deg, transform=ax.get_transform('icrs'), label='Crab Nebula')
+    ax.legend()
+
+
+if __name__ == '__main__':
+    runs = fio.read_data('crab_dl3.hdf5', key='runs')
+    dl3 = fio.read_data('crab_dl3.hdf5', key='events')
+
+    data = pd.merge(runs, dl3, on=['run_id', 'night'] )
+
+    timestamps = pd.to_datetime(data.timestamp).values
+    total_ontime = estimate_exposure_time(timestamps)
+    print('total exposure time: {}'.format(total_ontime.to(u.h)))
+
+    ra = data.ra_prediction.values * u.hourangle
+    dec = data.dec_prediction.values * u.deg
+
+    ra_pointing = data.right_ascension.values * u.hourangle
+    dec_pointing = data.declination.values * u.deg
+
+    event_coords = SkyCoord(ra=ra, dec=dec)
+    pointing_coords = SkyCoord(ra=ra_pointing, dec=dec_pointing)
+
+    mask, wcs, img = build_exposure_map(pointing_coords, timestamps)
+
+    ax = plot_exposure(img, mask, wcs)
+    plt.savefig('exposure.pdf')
+    # plt.show()

--- a/irf/exposure_map.py
+++ b/irf/exposure_map.py
@@ -27,6 +27,13 @@ def estimate_exposure_time(timestamps):
 
 @u.quantity_input(ra=u.hourangle, dec=u.deg, fov=u.deg)
 def build_exposure_regions(pointing_coords, fov=4.5 * u.deg):
+    '''
+    Takes a list of pointing positions and a field of view and returns
+    the unique pointing positions and the astropy.regions.
+
+    For an observation with N wobble positions this will return N unique
+    pointing positions and N circular regions.
+    '''
     unique_pointing_positions = SkyCoord(
         ra=np.unique(pointing_coords.ra),
         dec=np.unique(pointing_coords.dec)
@@ -57,7 +64,11 @@ def _build_standard_wcs(image_center, shape, naxis=2, fov=9 * u.deg):
 
 @u.quantity_input(event_ra=u.hourangle, event_dec=u.deg, fov=u.deg)
 def build_exposure_map(pointing_coords, event_time, fov=4.5 * u.deg, wcs=None, shape=(1000, 1000)):
-
+    '''
+    Takes pointing coordinates for each event and the corresponding timestamp.
+    Returns a masked array containing the estimated exposure time in hours
+    and a WCS object so the mask can be plotted. 
+    '''
     if not wcs:
         image_center = SkyCoord(ra=pointing_coords.ra.mean(), dec=pointing_coords.dec.mean())
         wcs = _build_standard_wcs(image_center, shape, fov=2 * fov)

--- a/irf/scripts/create_fact_exposure_map.py
+++ b/irf/scripts/create_fact_exposure_map.py
@@ -1,0 +1,122 @@
+from irf import estimate_exposure_time, build_exposure_map
+import click
+import fact.io as fio
+import pandas as pd
+from astroquery.skyview import SkyView
+from astropy.wcs import WCS
+from astropy.visualization import ImageNormalize, ZScaleInterval, AsinhStretch
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+import matplotlib.pyplot as plt
+
+
+@u.quantity_input(fov=u.deg)
+def get_sdss_sky_image(img_center, fov=9 * u.deg, n_pix=1000):
+    '''
+    A small helper method which uses astroquery to get an image from the sdss.
+    This requires internet access and fails pretty often due to http timeouts.
+    '''
+    hdu = SkyView.get_images(
+        position=img_center,
+        pixels=n_pix,
+        survey=['DSS'],
+        width=fov,
+        height=fov)[0][0]
+
+    img = hdu.data
+    wcs = WCS(hdu.header)
+    return img, wcs
+
+
+@click.command()
+@click.argument(
+    'dl3_path',
+    type=click.Path(file_okay=True, dir_okay=False),
+)
+@click.argument(
+    'output_path',
+    type=click.Path(file_okay=True, dir_okay=False, exists=False),
+)
+@click.option(
+    '-n',
+    '--n_pix',
+    default=1000,
+    help='number of pixels along the edge of the produced image',
+)
+@click.option(
+    '-s',
+    '--source_name',
+    default=None,
+    help=
+    'If supplied, e.g. "Crab Nebula" will draw the position of that source into the image',
+)
+@click.option(
+    '--background/--no-background',
+    default=True,
+    help='If true, downloads SDSS image for backgrund image in the plot')
+def main(dl3_path, output_path, n_pix, source_name, background):
+    '''
+    Takes FACT dl3 output and plots a skymap which is being saved to the output_path.
+    '''
+    runs = fio.read_data(dl3_path, key='runs')
+    dl3 = fio.read_data(dl3_path, key='events')
+
+    data = pd.merge(runs, dl3, on=['run_id', 'night'])
+
+    timestamps = pd.to_datetime(data.timestamp).values
+    total_ontime = estimate_exposure_time(timestamps)
+    print('Total estimated exposure time: {}'.format(total_ontime.to(u.h)))
+
+    ra_pointing = data.right_ascension.values * u.hourangle
+    dec_pointing = data.declination.values * u.deg
+    pointing = SkyCoord(ra=ra_pointing, dec=dec_pointing)
+
+    img = None
+    wcs = None
+    if background:
+        img_center = SkyCoord(ra=pointing.ra.mean(), dec=pointing.dec.mean())
+        img, wcs = get_sdss_sky_image(
+            img_center=img_center, n_pix=n_pix, fov=9 * u.deg)
+
+    mask, wcs = build_exposure_map(pointing, timestamps, shape=(n_pix, n_pix))
+
+    ax = plot_exposure(mask, wcs, image=img)
+    if source_name:
+        source = SkyCoord.from_name('Crab Nebula')
+        ax.scatter(
+            source.ra.deg,
+            source.dec.deg,
+            transform=ax.get_transform('icrs'),
+            label=source_name,
+            s=10**2,
+            facecolors='none',
+            edgecolors='r',
+        )
+        ax.legend()
+
+    plt.savefig(output_path, dpi=200)
+
+
+def plot_exposure(mask, wcs, image=None):
+    plt.figure(figsize=(10, 10))
+    ax = plt.subplot(projection=wcs)
+
+    if image is not None:
+        norm = ImageNormalize(
+            image,
+            interval=ZScaleInterval(contrast=0.05),
+            stretch=AsinhStretch(a=0.2))
+        ax.imshow(image, cmap='gray', norm=norm, interpolation='nearest')
+
+    d = ax.imshow(mask, alpha=0.7)
+    cb = plt.colorbar(d)
+    cb.set_label('Live Time / Hours')
+    ax.set_xlabel('Galactic Longitude')
+    ax.set_ylabel('Galactic Latitude')
+
+    return ax
+
+
+if __name__ == '__main__':
+    main()

--- a/irf/tests/test_exposure_map.py
+++ b/irf/tests/test_exposure_map.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+import fact.io as fio
+import pandas as pd
+from irf import estimate_exposure_time
+
+
+FIXTURE_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    'test_files',
+)
+
+
+@pytest.fixture
+def events():
+    return fio.read_data(os.path.join(FIXTURE_DIR, 'crab_dl3_sample.hdf5'), key='events')
+
+
+@pytest.fixture
+def runs():
+    return fio.read_data(os.path.join(FIXTURE_DIR, 'crab_dl3_sample.hdf5'), key='runs')
+
+
+
+def test_exposure_time(runs, events):
+        n_crab_sample = 687226
+        n_test_sample = len(events)
+
+        live_time_crab = runs.ontime.sum() / 3600  # to hours
+
+        expected_live_time_sample = n_test_sample / n_crab_sample * live_time_crab
+
+        timestamps = pd.to_datetime(events.timestamp).values
+        exposure = estimate_exposure_time(timestamps).to('h').value
+
+        assert expected_live_time_sample == pytest.approx(exposure, 0.05)

--- a/irf/tests/test_exposure_map.py
+++ b/irf/tests/test_exposure_map.py
@@ -2,7 +2,11 @@ import os
 import pytest
 import fact.io as fio
 import pandas as pd
-from irf import estimate_exposure_time
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+from irf import estimate_exposure_time, build_exposure_map
 
 
 FIXTURE_DIR = os.path.join(
@@ -22,15 +26,29 @@ def runs():
 
 
 
+def test_exposure_map(runs, events):
+    data = pd.merge(runs, events, on=['run_id', 'night'])
+
+    timestamps = pd.to_datetime(data.timestamp).values
+
+    ra_pointing = data.right_ascension.values * u.hourangle
+    dec_pointing = data.declination.values * u.deg
+    pointing = SkyCoord(ra=ra_pointing, dec=dec_pointing)
+
+    mask, wcs = build_exposure_map(pointing, timestamps, fov=4.5 * u.deg)
+
+    assert mask.mask.any()  # assert whether some region is masked
+
+
+
 def test_exposure_time(runs, events):
-        n_crab_sample = 687226
-        n_test_sample = len(events)
+    n_crab_sample = 687226
+    n_test_sample = len(events)
 
-        live_time_crab = runs.ontime.sum() / 3600  # to hours
+    live_time_crab = runs.ontime.sum() / 3600  # to hours
 
-        expected_live_time_sample = n_test_sample / n_crab_sample * live_time_crab
+    expected_live_time_sample = n_test_sample / n_crab_sample * live_time_crab
 
-        timestamps = pd.to_datetime(events.timestamp).values
-        exposure = estimate_exposure_time(timestamps).to('h').value
-
-        assert expected_live_time_sample == pytest.approx(exposure, 0.05)
+    timestamps = pd.to_datetime(events.timestamp).values
+    exposure = estimate_exposure_time(timestamps).to('h').value
+    assert expected_live_time_sample == pytest.approx(exposure, 0.05)


### PR DESCRIPTION
Some new functions and a script to create an exposure map. Live times are estimated from the event list alone. While one could use the 'ontime' field in FACTs hdf5 data, I wanted to keep this a little more general. Admittedly I haven't tested this on CTA data yet. 

![exposure_map](https://user-images.githubusercontent.com/4076745/36268371-92099c3c-1276-11e8-96cf-ec8d87f2d79a.png)
